### PR TITLE
Handle `$KEEP_NUM_RECENT` being set to 0

### DIFF
--- a/sbin/lamp-backup.sh
+++ b/sbin/lamp-backup.sh
@@ -287,8 +287,10 @@ if [ "$VERBOSE" -ge 0 ]; then
     echo "---------------"
     now=$(date +%s)
     echo "Elapsed time: $((now - $STARTTIME)) seconds."
-    echo "Disk space used:"
-    du -sh $fullpath
+    if [ "$KEEP_NUM_RECENT" -ne "0" ]; then
+        echo "Disk space used:"
+        du -sh $fullpath
+    fi
     echo "Disk space available on backup partition:"
     df -h $OUTPUT_BASE_DIR
 fi


### PR DESCRIPTION
First of all, thanks for open sourcing this! I looked around at a lot of options and this fit my needs best.

I was playing around with these config options:

```
KEEP_NUM_RECENT=0
KEEP_NUM_MONTHLIES=0
```

And noticed errors like:

```
du: cannot access `/var/backup/backup_2015-02-10-1423608909': No such file or directory
```

This change accounts for the possibility that the local backups may have been immediately rotated out. Another approach would be to check and store the disk space used _before_ rotating. This is the quick and dirty "solution" to get the discussion started, I'd be happy to dig deeper to come up with a better PR :)

Edit: …although checking the disk space ahead of time it would still be displaying a non-existent directory so that probably wouldn't make sense. So this is maybe the simplest and least confusing solution for this without having to check S3 configuration and all that.
